### PR TITLE
Modified build script with built app name

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,6 @@ JAVA_HOME=$(/usr/libexec/java_home -v 1.8 -a arm64) \
     -DLauncher_META_URL="https://minecraftmachina.github.io/meta-multimc-arm64/" \
     -DLauncher_EMBED_SECRETS=$(test -d secrets && echo "ON" || echo "OFF")
 make -C "build" -j$(sysctl -n hw.physicalcpu) install
-chmod -R u+w "dist/ManyMC.app"
-find "dist/ManyMC.app" -depth -exec codesign -f -s - {} \;
-codesign -f --no-strict -s - --entitlements "entitlements.plist" "dist/ManyMC.app"
+chmod -R u+w "dist/DevLauncher.app"
+find "dist/DevLauncher.app" -depth -exec codesign -f -s - {} \;
+codesign -f --no-strict -s - --entitlements "entitlements.plist" "dist/DevLauncher.app"


### PR DESCRIPTION
I noticed the build script expects the built app to be named ManyMC.app (which I'm assuming is the actual intended name) however I found that the actual built app in `dist/` is `DevLauncher.app` so I modified the build.sh file to properly deal with that.